### PR TITLE
Add support for Mac Catalyst (on Intel and Apple Silicon chips)

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -70,6 +70,20 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
             ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
         ],
     ),
+    (
+        "aarch64-apple-ios-macabi",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "arm64"),
+            ("CMAKE_OSX_SYSROOT", "macosx"),
+        ],
+    ),
+    (
+        "x86_64-apple-ios-macabi",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
+            ("CMAKE_OSX_SYSROOT", "macosx"),
+        ],
+    ),
 ];
 
 fn cmake_params_ios() -> &'static [(&'static str, &'static str)] {
@@ -141,6 +155,7 @@ const BORING_SSL_PATH: &str = "deps/boringssl";
 fn get_boringssl_cmake_config() -> cmake::Config {
     let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target = std::env::var("TARGET").unwrap();
     let pwd = std::env::current_dir().unwrap();
 
     let mut boringssl_cmake = cmake::Config::new(BORING_SSL_PATH);
@@ -178,17 +193,29 @@ fn get_boringssl_cmake_config() -> cmake::Config {
             // Bitcode is always on.
             let bitcode_cflag = "-fembed-bitcode";
 
-            // Hack for Xcode 10.1.
-            let target_cflag = if arch == "x86_64" {
-                "-target x86_64-apple-ios-simulator"
+            if target.ends_with("-macabi") {
+                // Mac Catalyst
+                let compiler_flags = format!("{} -target {}", bitcode_cflag, target);
+                boringssl_cmake.define("CMAKE_ASM_FLAGS", &compiler_flags);
+                // Work around hardcoded deployment target in cc crate by defining CMAKE_C_FLAGS
+                // instead of using the cflag builder.
+                boringssl_cmake.define("CMAKE_C_FLAGS", &compiler_flags);
+                boringssl_cmake.define("CMAKE_CXX_FLAGS", &compiler_flags);
             } else {
-                ""
-            };
+                // Normal iOS
 
-            let cflag = format!("{} {}", bitcode_cflag, target_cflag);
+                // Hack for Xcode 10.1.
+                let target_cflag = if arch == "x86_64" {
+                    "-target x86_64-apple-ios-simulator"
+                } else {
+                    ""
+                };
 
-            boringssl_cmake.define("CMAKE_ASM_FLAGS", &cflag);
-            boringssl_cmake.cflag(&cflag);
+                let cflag = format!("{} {}", bitcode_cflag, target_cflag);
+
+                boringssl_cmake.define("CMAKE_ASM_FLAGS", &cflag);
+                boringssl_cmake.cflag(&cflag);
+            }
 
             boringssl_cmake
         }
@@ -394,7 +421,7 @@ fn main() {
         // so let's disable all alignment tests and hope for the best.
         //
         // [1]: https://github.com/rust-lang/rust-bindgen/issues/1651
-        "aarch64-apple-ios" | "aarch64-apple-ios-sim" => {
+        "aarch64-apple-ios" | "aarch64-apple-ios-sim" | "aarch64-apple-ios-macabi" => {
             builder = builder.layout_tests(false);
         }
         _ => {}


### PR DESCRIPTION
This is a Tier 3 target, but apart from working around a hardcoded version in the 'cc' crate everything does work. (See rust-lang/cc-rs#678…but there's history there!)