### PR TITLE
boring-sys: Save time by not building the bssl CLI utility

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -357,7 +357,8 @@ fn main() {
             cfg.define("FIPS", "1");
         }
 
-        cfg.build_target("bssl").build().display().to_string()
+        cfg.build_target("ssl").build();
+        cfg.build_target("crypto").build().display().to_string()
     });
 
     let build_path = get_boringssl_platform_output_path();


### PR DESCRIPTION
We only need libcrypto and libssl. On my machine, this saves about 20s when building just boring-sys (clean `--release` build time of 60s instead of 80s).