### PR TITLE
Add minimal cross-compilation support for Windows and AArch64 Linux

### DIFF
--- a/boring-sys/cmake/aarch64-linux.cmake
+++ b/boring-sys/cmake/aarch64-linux.cmake
@@ -1,0 +1,3 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+# Rely on environment variables to set the compiler and include paths.


### PR DESCRIPTION
Cross-compiling to AArch64 Linux can be done with a CMake toolchain file, along with setting the correct compiler and include paths in the environment.

Cross-compiling from X64 Windows to ARM64 Windows doesn't look at the toolchain at all, because CMake + Visual Studio can already cross-compile. Unfortunately, the Visual Studio CMake generator doesn't set `CMAKE_SYSTEM_PROCESSOR`, which is what the BoringSSL CMakeLists.txt is looking at to choose the architecture. For now, disable the use of assembly when cross-compiling on Windows (assuming that the Visual Studio generator will be used there).

Best reviewed with whitespace diffing turned off.