### PR TITLE
boring-sys: Always treat macOS targets as a cross-compile, like iOS

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -48,7 +48,8 @@ fn cmake_params_android() -> &'static [(&'static str, &'static str)] {
     &[]
 }
 
-const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
+const CMAKE_PARAMS_APPLE: &[(&str, &[(&str, &str)])] = &[
+    // iOS
     (
         "aarch64-apple-ios",
         &[
@@ -70,6 +71,7 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
             ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
         ],
     ),
+    // Mac Catalyst
     (
         "aarch64-apple-ios-macabi",
         &[
@@ -84,26 +86,41 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
             ("CMAKE_OSX_SYSROOT", "macosx"),
         ],
     ),
+    // macOS
+    (
+        "aarch64-apple-darwin",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "arm64"),
+            ("CMAKE_OSX_SYSROOT", "macosx"),
+        ],
+    ),
+    (
+        "x86_64-apple-darwin",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
+            ("CMAKE_OSX_SYSROOT", "macosx"),
+        ],
+    ),
 ];
 
-fn cmake_params_ios() -> &'static [(&'static str, &'static str)] {
+fn cmake_params_apple() -> &'static [(&'static str, &'static str)] {
     let target = std::env::var("TARGET").unwrap();
-    for (ios_target, params) in CMAKE_PARAMS_IOS {
-        if *ios_target == target {
+    for (next_target, params) in CMAKE_PARAMS_APPLE {
+        if *next_target == target {
             return *params;
         }
     }
     &[]
 }
 
-fn get_ios_sdk_name() -> &'static str {
-    for (name, value) in cmake_params_ios() {
+fn get_apple_sdk_name() -> &'static str {
+    for (name, value) in cmake_params_apple() {
         if *name == "CMAKE_OSX_SYSROOT" {
             return *value;
         }
     }
     let target = std::env::var("TARGET").unwrap();
-    panic!("cannot find iOS SDK for {} in CMAKE_PARAMS_IOS", target);
+    panic!("cannot find SDK for {} in CMAKE_PARAMS_APPLE", target);
 }
 
 /// Returns the platform-specific output path for lib.
@@ -183,8 +200,15 @@ fn get_boringssl_cmake_config() -> cmake::Config {
                 boringssl_cmake.define("ANDROID_STL", "c++_shared");
             }
 
+            "macos" => {
+                for (name, value) in cmake_params_apple() {
+                    eprintln!("macos arch={} add {}={}", arch, name, value);
+                    boringssl_cmake.define(name, value);
+                }
+            }
+
             "ios" => {
-                for (name, value) in cmake_params_ios() {
+                for (name, value) in cmake_params_apple() {
                     eprintln!("ios arch={} add {}={}", arch, name, value);
                     boringssl_cmake.define(name, value);
                 }
@@ -309,11 +333,11 @@ fn get_extra_clang_args_for_bindgen() -> Vec<String> {
     // Add platform-specific parameters.
     #[allow(clippy::single_match)]
     match os.as_ref() {
-        "ios" => {
+        "ios" | "macos" => {
             use std::io::Write;
-            // When cross-compiling for iOS, tell bindgen to use iOS sysroot,
+            // When cross-compiling for Apple targets, tell bindgen to use SDK sysroot,
             // and *don't* use system headers of the host macOS.
-            let sdk = get_ios_sdk_name();
+            let sdk = get_apple_sdk_name();
             let output = std::process::Command::new("xcrun")
                 .args(["--show-sdk-path", "--sdk", sdk])
                 .output()


### PR DESCRIPTION
This fixes actual cross-compile cases, like compiling for Apple Silicon on an Intel Mac. It also makes builds more consistent by using the SDK in the installed Xcode instead of the host root headers, which is how Apple recommends people build anyway. (If you only have the command line tools installed, though, it should fall back to those without a problem.)