### PR TITLE
Update bindgen to 0.70.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ boring-sys = { version = "4.9.0", path = "./boring-sys", default-features = fals
 boring = { version = "4.9.0", path = "./boring" }
 tokio-boring = { version = "4.9.0", path = "./tokio-boring" }
 
-bindgen = { version = "0.68.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.70.1", default-features = false, features = ["runtime"] }
 cmake = "0.1.18"
 fs_extra = "1.3.0"
 fslock = "0.2"


### PR DESCRIPTION
Cherry-pick of https://github.com/cloudflare/boring/pull/273, pending a full update to the latest Cloudflare release, to fix https://github.com/signalapp/boring/issues/28.